### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ An MCP server that provides access to LumbreTravel API.
 
 [LumbreTravel](https://lumbretravel.com.ar/) is a platform for managing travel programs and activities and this is the MCP server for it.  That allows you to use it on [Claude Desktop](https://claude.ai/download) or other MCP clients.
 
+<a href="https://glama.ai/mcp/servers/tp79r72xyd"><img width="380" height="200" src="https://glama.ai/mcp/servers/tp79r72xyd/badge" alt="LumbreTravel Server MCP server" /></a>
+
 ## Features
 
 This MCP Server allows access to all the tools that LumbreTravel API provides.


### PR DESCRIPTION
This PR adds a badge for the [LumbreTravel MCP Server](https://glama.ai/mcp/servers/tp79r72xyd) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/tp79r72xyd"><img width="380" height="200" src="https://glama.ai/mcp/servers/tp79r72xyd/badge" alt="LumbreTravel Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.